### PR TITLE
Add Migration Reserve

### DIFF
--- a/packages/emptyset-reserve/contracts/interfaces/IMigrationReserve.sol
+++ b/packages/emptyset-reserve/contracts/interfaces/IMigrationReserve.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "@equilibria/root/number/types/UFixed18.sol";
+import "@equilibria/root/token/types/Token18.sol";
+import "@equilibria/root/token/types/Token6.sol";
+import "./IReserve.sol";
+
+/**
+ * @title IMigrationReserve
+ * @notice Interface for the migration reserve
+ */
+interface IMigrationReserve is IReserve {
+    event Migrate(address indexed account, UFixed18 amount);
+
+    function migrate(UFixed18 amount) external;
+}

--- a/packages/emptyset-reserve/contracts/reserve/MigrationReserve.sol
+++ b/packages/emptyset-reserve/contracts/reserve/MigrationReserve.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.17;
+
+import "@equilibria/root/number/types/UFixed18.sol";
+import "./SimpleReserve.sol";
+
+contract MigrationReserve is SimpleReserve {
+    Token6 public immutable USDC_BRIDGED; // solhint-disable-line var-name-mixedcase
+
+    constructor(Token18 dsu_, Token6 usdc_, Token6 usdcBridged_) SimpleReserve(dsu_, usdc_) {
+        USDC_BRIDGED = usdcBridged_;
+    }
+
+    function migrate(UFixed18 amount) external {
+        USDC.pull(msg.sender, amount, true);
+        USDC_BRIDGED.push(msg.sender, amount);
+    }
+}

--- a/packages/emptyset-reserve/contracts/reserve/MigrationReserve.sol
+++ b/packages/emptyset-reserve/contracts/reserve/MigrationReserve.sol
@@ -2,9 +2,10 @@
 pragma solidity 0.8.17;
 
 import "@equilibria/root/number/types/UFixed18.sol";
+import "../interfaces/IMigrationReserve.sol";
 import "./SimpleReserve.sol";
 
-contract MigrationReserve is SimpleReserve {
+contract MigrationReserve is IMigrationReserve, SimpleReserve {
     Token6 public immutable USDC_BRIDGED; // solhint-disable-line var-name-mixedcase
 
     constructor(Token18 dsu_, Token6 usdc_, Token6 usdcBridged_) SimpleReserve(dsu_, usdc_) {
@@ -12,7 +13,9 @@ contract MigrationReserve is SimpleReserve {
     }
 
     function migrate(UFixed18 amount) external {
-        USDC.pull(msg.sender, amount, true);
+        USDC.pull(msg.sender, amount);
         USDC_BRIDGED.push(msg.sender, amount);
+
+        emit Migrate(msg.sender, amount);
     }
 }

--- a/packages/emptyset-reserve/test/unit/reserve/MigrationReserve.test.ts
+++ b/packages/emptyset-reserve/test/unit/reserve/MigrationReserve.test.ts
@@ -1,0 +1,65 @@
+import { FakeContract, smock } from '@defi-wonderland/smock'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect, use } from 'chai'
+import { utils } from 'ethers'
+import HRE from 'hardhat'
+import { DSU, IERC20Metadata, MigrationReserve, MigrationReserve__factory } from '../../../types/generated'
+
+const { ethers } = HRE
+use(smock.matchers)
+
+describe('MigrationReserve', () => {
+  let owner: SignerWithAddress
+  let user: SignerWithAddress
+  let reserve: MigrationReserve
+  let usdc: FakeContract<IERC20Metadata>
+  let usdcBridged: FakeContract<IERC20Metadata>
+  let dsu: FakeContract<DSU>
+
+  beforeEach(async () => {
+    ;[owner, user] = await ethers.getSigners()
+
+    usdc = await smock.fake<IERC20Metadata>('IERC20Metadata')
+    usdcBridged = await smock.fake<IERC20Metadata>('IERC20Metadata')
+    dsu = await smock.fake<DSU>('DSU')
+
+    dsu.decimals.returns(18)
+    usdc.decimals.returns(6)
+
+    reserve = await new MigrationReserve__factory(owner).deploy(dsu.address, usdc.address, usdcBridged.address)
+  })
+
+  describe('#constructor', () => {
+    it('constructs correctly', async () => {
+      expect(await reserve.DSU()).to.equal(dsu.address)
+      expect(await reserve.USDC()).to.equal(usdc.address)
+      expect(await reserve.USDC_BRIDGED()).to.equal(usdcBridged.address)
+    })
+  })
+
+  describe('#migrate', () => {
+    it('pulls USDC from the sender, wraps it as DSU', async () => {
+      const amount = utils.parseEther('10')
+
+      usdc.transferFrom.whenCalledWith(user.address, reserve.address, 10e6).returns(true)
+      usdcBridged.transfer.whenCalledWith(user.address, 10e6).returns(true)
+
+      await expect(reserve.connect(user).migrate(amount)).to.emit(reserve, 'Migrate').withArgs(user.address, amount)
+
+      expect(usdc.transferFrom).to.have.been.calledWith(user.address, reserve.address, 10e6)
+      expect(usdcBridged.transfer).to.have.been.calledWith(user.address, 10e6)
+    })
+
+    it('pulls USDC from the sender, wraps it as DSU with rounding', async () => {
+      const amount = utils.parseEther('10').add(1)
+
+      usdc.transferFrom.whenCalledWith(user.address, reserve.address, 10e6).returns(true)
+      usdcBridged.transfer.whenCalledWith(user.address, 10e6).returns(true)
+
+      await expect(reserve.connect(user).migrate(amount)).to.emit(reserve, 'Migrate').withArgs(user.address, amount)
+
+      expect(usdc.transferFrom).to.have.been.calledWith(user.address, reserve.address, 10e6)
+      expect(usdcBridged.transfer).to.have.been.calledWith(user.address, 10e6)
+    })
+  })
+})

--- a/packages/emptyset-reserve/test/unit/reserve/MigrationReserve.test.ts
+++ b/packages/emptyset-reserve/test/unit/reserve/MigrationReserve.test.ts
@@ -38,7 +38,7 @@ describe('MigrationReserve', () => {
   })
 
   describe('#migrate', () => {
-    it('pulls USDC from the sender, wraps it as DSU', async () => {
+    it('pulls native USDC from the sender, returns bridge USDC', async () => {
       const amount = utils.parseEther('10')
 
       usdc.transferFrom.whenCalledWith(user.address, reserve.address, 10e6).returns(true)
@@ -50,7 +50,7 @@ describe('MigrationReserve', () => {
       expect(usdcBridged.transfer).to.have.been.calledWith(user.address, 10e6)
     })
 
-    it('pulls USDC from the sender, wraps it as DSU with rounding', async () => {
+    it('pulls native USDC from the sender, returns bridge USDC with rounding', async () => {
       const amount = utils.parseEther('10').add(1)
 
       usdc.transferFrom.whenCalledWith(user.address, reserve.address, 10e6).returns(true)


### PR DESCRIPTION
Adds a variant of the `SimpleReserve` that allows for one-way migration from bridged to native `USDC`.