### PR TITLE
Add Claim2Step

### DIFF
--- a/packages/emptyset-reserve/contracts/claim/Claim2Step.sol
+++ b/packages/emptyset-reserve/contracts/claim/Claim2Step.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.35;
+
+import { Token6 } from "@equilibria/root/token/types/Token6.sol";
+import { Token18 } from "@equilibria/root/token/types/Token18.sol";
+import { UFixed6, UFixed6Lib } from "@equilibria/root/number/types/UFixed6.sol";
+import { UFixed18, UFixed18Lib } from "@equilibria/root/number/types/UFixed18.sol";
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IGovToken is IERC20 {
+    function delegate(address delegatee) external;
+    function delegates(address account) external view returns (address);
+}
+
+contract Delegatable is Ownable {
+    Token18 public immutable token;
+
+    constructor(Token18 token_, address delegate_) {
+        token = token_;
+        _g().delegate(delegate_);
+    }
+
+    function close() external onlyOwner {
+        token.push(_g().delegates(address(this)), token.balanceOf());
+    }
+
+    function _g() private view returns (IGovToken) {
+        return IGovToken(Token18.unwrap(token));
+    }
+}
+
+contract Claim2Step is Ownable2Step {
+    error ClosedError();
+    error OpenedError();
+    error NotInitializedError();
+    error NotImplementedError();
+
+    event Locked(address indexed account, UFixed18 amount, UFixed6 reward);
+    event Unlocked(address indexed account, UFixed18 amount, UFixed6 reward);
+
+    Token6 public immutable fiat;
+    Token18 public immutable token;
+    uint256 public immutable deadline;
+
+    UFixed18 public totalLocked;
+    mapping(address => UFixed18) public lockedOf;
+    mapping(address => Delegatable) public delegates;
+
+    constructor(address owner_, Token6 fiat_, Token18 token_, uint256 deadline_) {
+        fiat = fiat_;
+        token = token_;
+        deadline = deadline_;
+        super.transferOwnership(owner_);
+    }
+
+    function transferOwnership(address) public pure override {
+        revert NotImplementedError();
+    }
+
+    function renounceOwnership() public pure override {
+        revert NotImplementedError();
+    }
+
+    function lock(UFixed18 amount) external {
+        if (!initialized()) revert NotInitializedError();
+        if (closed()) revert ClosedError();
+
+        Delegatable delegate = _deployOrGet(msg.sender);
+        UFixed18 unlockedSupply = token.totalSupply().sub(totalLocked);
+        UFixed6 reward = UFixed6Lib.from(UFixed18Lib.from(fiat.balanceOf()).muldiv(amount, unlockedSupply));
+
+        totalLocked = totalLocked.add(amount);
+        lockedOf[msg.sender] = lockedOf[msg.sender].add(amount);
+
+        token.pullTo(msg.sender, address(delegate), amount);
+        fiat.push(msg.sender, reward);
+
+        emit Locked(msg.sender, amount, reward);
+    }
+
+    function unlock() external {
+        if (!closed()) revert OpenedError();
+
+        UFixed18 amount = lockedOf[msg.sender];
+        UFixed6 reward = UFixed6Lib.from(UFixed18Lib.from(fiat.balanceOf()).muldiv(amount, totalLocked));
+
+        totalLocked = totalLocked.sub(amount);
+        lockedOf[msg.sender] = lockedOf[msg.sender].sub(amount);
+
+        delegates[msg.sender].close();
+        fiat.push(msg.sender, reward);
+
+        emit Unlocked(msg.sender, amount, reward);
+    }
+
+    function initialized() public view returns (bool) {
+        return pendingOwner() == address(0);
+    }
+
+    function closed() public view returns (bool) {
+        return block.timestamp >= deadline;
+    }
+
+    function _deployOrGet(address account) private returns (Delegatable delegate) {
+        if (address(delegate = delegates[account]) == address(0)) {
+            delegate = new Delegatable(token, account);
+            delegates[account] = delegate;
+        }
+    }
+}

--- a/test/mocks/MockGovToken.sol
+++ b/test/mocks/MockGovToken.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import { ERC20Votes } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+
+/// @dev An 18-decimal ERC20Votes governance token for exercising the Claim2Step delegation flow.
+contract MockGovToken is ERC20Votes {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) ERC20Permit(name_) {}
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+}

--- a/test/reserve/Claim2Step.mainnet.t.sol
+++ b/test/reserve/Claim2Step.mainnet.t.sol
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { Test } from "forge-std/Test.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Token6 } from "@equilibria/root/token/types/Token6.sol";
+import { Token18 } from "@equilibria/root/token/types/Token18.sol";
+import { UFixed18 } from "@equilibria/root/number/types/UFixed18.sol";
+import { Claim2Step, Delegatable } from "@emptyset/reserve/contracts/claim/Claim2Step.sol";
+
+interface IGovernorLike {
+    function propose(
+        address[] calldata targets,
+        uint256[] calldata values,
+        string[] calldata signatures,
+        bytes[] calldata calldatas,
+        string calldata description
+    ) external returns (uint256);
+    function castVote(uint256 proposalId, bool support) external;
+    function queue(uint256 proposalId) external;
+    function execute(uint256 proposalId) external payable;
+    function proposals(uint256 proposalId) external view returns (
+        uint256 id,
+        address proposer,
+        uint256 eta,
+        uint256 startBlock,
+        uint256 endBlock,
+        uint256 forVotes,
+        uint256 againstVotes,
+        bool canceled,
+        bool executed
+    );
+    function proposalThreshold() external view returns (uint256);
+    function quorumVotes() external view returns (uint256);
+    function state(uint256 proposalId) external view returns (uint8);
+}
+
+/// @dev Comp/Uni-style governance token surface used by ESS.
+interface IEssLike is IERC20 {
+    function delegate(address delegatee) external;
+    function getCurrentVotes(address account) external view returns (uint256);
+}
+
+/// @dev End-to-end: a real GovernorAlpha proposal funds and initializes a freshly deployed Claim2Step, then
+///      holders lock/unlock ESS and keep their voting power throughout. Fork-gated on MAINNET_NODE_URL.
+contract Claim2StepMainnetTest is Test {
+    address private constant TIMELOCK = 0x1bba92F379375387bf8F927058da14D47464cB7A;
+    address private constant GOVERNOR = 0x47C61a54B1d24d571F07a79d54543231292f769b;
+    address private constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address private constant ESS = 0x24aE124c4CC33D6791F8E8B63520ed7107ac8b3e;
+
+    uint256 private constant DURATION = 180 days;
+    uint256 private constant REWARD = 900_000e6;
+
+    // GovernorAlpha proposal states
+    uint8 private constant ACTIVE = 1;
+    uint8 private constant SUCCEEDED = 4;
+    uint8 private constant QUEUED = 5;
+    uint8 private constant EXECUTED = 7;
+
+    IGovernorLike private governor = IGovernorLike(GOVERNOR);
+    IEssLike private ess = IEssLike(ESS);
+    IERC20 private usdc = IERC20(USDC);
+
+    bool private forkUnavailable;
+
+    function setUp() public {
+        string memory rpc = vm.envOr("MAINNET_NODE_URL", string(""));
+        forkUnavailable = bytes(rpc).length == 0;
+        if (forkUnavailable) return;
+
+        uint256 forkBlock = vm.envOr("MAINNET_FORK_BLOCK_NUMBER", uint256(0));
+        if (forkBlock == 0) vm.createSelectFork(rpc);
+        else vm.createSelectFork(rpc, forkBlock);
+    }
+
+    function testGovernanceFundsInitializesAndRunsClaim() public {
+        vm.skip(forkUnavailable);
+
+        uint256 deadline = block.timestamp + DURATION;
+        Claim2Step claim =
+            new Claim2Step(TIMELOCK, Token6.wrap(USDC), Token18.wrap(ESS), deadline);
+
+        // the treasury holds the reward that the proposal will route into the claim
+        deal(USDC, TIMELOCK, REWARD);
+
+        _passProposal(address(claim));
+
+        // proposal outcome: funded, owned by the timelock, and open for locking
+        assertTrue(claim.initialized());
+        assertEq(claim.owner(), TIMELOCK);
+        assertEq(usdc.balanceOf(address(claim)), REWARD);
+        assertEq(Token18.unwrap(claim.token()), ESS);
+        assertEq(Token6.unwrap(claim.fiat()), USDC);
+
+        _runClaim(claim, deadline);
+    }
+
+    /// @dev Build the two-action proposal, give a proposer voting weight, and drive it to execution.
+    function _passProposal(address claim) private {
+        address[] memory targets = new address[](2);
+        uint256[] memory values = new uint256[](2);
+        string[] memory signatures = new string[](2);
+        bytes[] memory calldatas = new bytes[](2);
+
+        targets[0] = USDC;
+        signatures[0] = "transfer(address,uint256)";
+        calldatas[0] = abi.encode(claim, REWARD);
+
+        targets[1] = claim;
+        signatures[1] = "acceptOwnership()";
+        calldatas[1] = "";
+
+        address proposer = makeAddr("proposer");
+        deal(ESS, proposer, governor.quorumVotes() + governor.proposalThreshold() + 1_000e18, true);
+        vm.prank(proposer);
+        ess.delegate(proposer); // checkpoint the proposer's voting weight
+        vm.roll(block.number + 1);
+
+        vm.prank(proposer);
+        uint256 id = governor.propose(targets, values, signatures, calldatas, "Claim2Step: fund and initialize");
+
+        (,,, uint256 startBlock, uint256 endBlock,,,,) = governor.proposals(id);
+        vm.roll(startBlock + 1);
+        assertEq(governor.state(id), ACTIVE);
+
+        vm.prank(proposer);
+        governor.castVote(id, true);
+
+        vm.roll(endBlock + 1);
+        assertEq(governor.state(id), SUCCEEDED);
+
+        governor.queue(id);
+        assertEq(governor.state(id), QUEUED);
+        (,, uint256 eta,,,,,,) = governor.proposals(id);
+        vm.warp(eta + 1);
+
+        governor.execute(id);
+        assertEq(governor.state(id), EXECUTED);
+    }
+
+    /// @dev Two holders lock ESS (keeping their votes via the per-user wrapper), govern while locked, then
+    ///      sweep the pool on unlock. Each locks a quorum-sized weight so the two of them can carry a proposal.
+    function _runClaim(Claim2Step claim, uint256 deadline) private {
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+        uint256 aLock = governor.quorumVotes();
+        uint256 bLock = governor.quorumVotes();
+        deal(ESS, alice, aLock, true);
+        deal(ESS, bob, bLock, true);
+        vm.prank(alice);
+        ess.approve(address(claim), type(uint256).max);
+        vm.prank(bob);
+        ess.approve(address(claim), type(uint256).max);
+
+        uint256 supply = ess.totalSupply(); // constant across the lock phase (locks are transfers)
+
+        // --- phase 1: lock ---
+        uint256 rewardA = usdc.balanceOf(address(claim)) * aLock / (supply - _totalLocked(claim));
+        assertGt(rewardA, 0);
+        assertEq(ess.getCurrentVotes(alice), 0);
+        vm.prank(alice);
+        claim.lock(UFixed18.wrap(aLock));
+        assertEq(usdc.balanceOf(alice), rewardA);
+        assertEq(ess.balanceOf(alice), 0);
+        // custody moved to the wrapper, but alice keeps the voting power
+        assertEq(ess.balanceOf(address(claim.delegates(alice))), aLock);
+        assertEq(ess.getCurrentVotes(alice), aLock);
+
+        uint256 rewardB = usdc.balanceOf(address(claim)) * bLock / (supply - _totalLocked(claim));
+        vm.prank(bob);
+        claim.lock(UFixed18.wrap(bLock));
+        assertEq(usdc.balanceOf(bob), rewardB);
+        assertEq(ess.getCurrentVotes(bob), bLock);
+
+        // --- while locked: the holders govern with their preserved voting power ---
+        assertFalse(claim.closed()); // still inside the lock window
+        _passLockedHolderProposal(alice, bob, aLock, bLock);
+
+        // --- phase 2: unlock ---
+        vm.warp(deadline);
+        assertTrue(claim.closed());
+
+        uint256 sweepA = usdc.balanceOf(address(claim)) * aLock / _totalLocked(claim);
+        vm.prank(alice);
+        claim.unlock();
+        assertEq(usdc.balanceOf(alice), rewardA + sweepA);
+        assertEq(ess.balanceOf(alice), aLock); // gov returned...
+        assertEq(ess.getCurrentVotes(alice), 0); // ...and voting power released with it
+
+        // bob is the last locker, so his unlock sweeps the remainder of the pool
+        uint256 sweepB = usdc.balanceOf(address(claim));
+        vm.prank(bob);
+        claim.unlock();
+        assertEq(usdc.balanceOf(bob), rewardB + sweepB);
+        assertEq(ess.balanceOf(bob), bLock);
+        assertEq(usdc.balanceOf(address(claim)), 0);
+    }
+
+    /// @dev A fresh proposal, proposed by locked-holder `alice` and carried to execution by the votes of both
+    ///      locked holders — proving locking custody into the claim does not surrender governance power.
+    function _passLockedHolderProposal(address alice, address bob, uint256 aLock, uint256 bLock) private {
+        GovTarget target = new GovTarget();
+
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        string[] memory signatures = new string[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        targets[0] = address(target);
+        signatures[0] = "ping()";
+        calldatas[0] = "";
+
+        vm.roll(block.number + 1);
+        vm.prank(alice); // alice proposes using only her locked (wrapper-delegated) weight
+        uint256 id = governor.propose(targets, values, signatures, calldatas, "Locked holders govern");
+
+        (,,, uint256 startBlock, uint256 endBlock,,,,) = governor.proposals(id);
+        vm.roll(startBlock + 1);
+        assertEq(governor.state(id), ACTIVE);
+
+        vm.prank(alice);
+        governor.castVote(id, true);
+        vm.prank(bob);
+        governor.castVote(id, true);
+
+        // the entire winning tally is locked ESS voting through the wrappers
+        (,,,,, uint256 forVotes,,,) = governor.proposals(id);
+        assertEq(forVotes, aLock + bLock);
+        assertGe(forVotes, governor.quorumVotes());
+
+        vm.roll(endBlock + 1);
+        assertEq(governor.state(id), SUCCEEDED);
+        governor.queue(id);
+        (,, uint256 eta,,,,,,) = governor.proposals(id);
+        vm.warp(eta + 1);
+        governor.execute(id);
+        assertEq(governor.state(id), EXECUTED);
+
+        assertTrue(target.pinged()); // the locked holders' proposal actually executed
+    }
+
+    function _totalLocked(Claim2Step claim) private view returns (uint256) {
+        return UFixed18.unwrap(claim.totalLocked());
+    }
+}
+
+/// @dev Trivial governance target so an executed proposal leaves an observable on-chain effect.
+contract GovTarget {
+    bool public pinged;
+
+    function ping() external {
+        pinged = true;
+    }
+}

--- a/test/reserve/Claim2Step.t.sol
+++ b/test/reserve/Claim2Step.t.sol
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import { Test } from "forge-std/Test.sol";
+import { Token6 } from "@equilibria/root/token/types/Token6.sol";
+import { Token18 } from "@equilibria/root/token/types/Token18.sol";
+import { UFixed18 } from "@equilibria/root/number/types/UFixed18.sol";
+import { Claim2Step, Delegatable } from "@emptyset/reserve/contracts/claim/Claim2Step.sol";
+import { MockERC20 } from "../mocks/MockERC20.sol";
+import { MockGovToken } from "../mocks/MockGovToken.sol";
+
+contract Claim2StepTest is Test {
+    MockERC20 private usdc;
+    MockGovToken private gov;
+    Claim2Step private claim;
+
+    address private governor = makeAddr("governor");
+    address private a = makeAddr("a");
+    address private b = makeAddr("b");
+    address private c = makeAddr("c");
+
+    uint256 private constant DURATION = 180 days;
+    uint256 private constant SUPPLY = 1000e18;
+    uint256 private constant REWARD = 900e6;
+
+    uint256 private deadline;
+
+    function setUp() public {
+        usdc = new MockERC20("USD Coin", "USDC", 6);
+        gov = new MockGovToken("Governance Token", "GOV");
+
+        deadline = block.timestamp + DURATION;
+        claim = new Claim2Step(governor, Token6.wrap(address(usdc)), Token18.wrap(address(gov)), deadline);
+
+        gov.mint(a, 500e18);
+        gov.mint(b, 300e18);
+        gov.mint(c, 200e18);
+        assertEq(gov.totalSupply(), SUPPLY);
+
+        vm.prank(a);
+        gov.approve(address(claim), type(uint256).max);
+        vm.prank(b);
+        gov.approve(address(claim), type(uint256).max);
+        vm.prank(c);
+        gov.approve(address(claim), type(uint256).max);
+    }
+
+    /// @dev Funds the pool, mirroring the treasury transferring the reward in before kickoff
+    function _fund() private {
+        usdc.mint(address(claim), REWARD);
+    }
+
+    /// @dev The governor accepts ownership, which opens the lock phase
+    function _initialize() private {
+        vm.prank(governor);
+        claim.acceptOwnership();
+    }
+
+    function _wrapperOf(address account) private view returns (address) {
+        return address(claim.delegates(account));
+    }
+
+    function _locked(address account) private view returns (uint256) {
+        return gov.balanceOf(_wrapperOf(account));
+    }
+
+    // --- construction & lifecycle ---
+
+    function testConstructor() public {
+        assertEq(Token6.unwrap(claim.fiat()), address(usdc));
+        assertEq(Token18.unwrap(claim.token()), address(gov));
+        assertEq(claim.deadline(), deadline);
+        assertEq(claim.owner(), address(this));
+        assertEq(claim.pendingOwner(), governor);
+        assertFalse(claim.initialized());
+        assertFalse(claim.closed());
+    }
+
+    function testInitializeViaAcceptOwnership() public {
+        _initialize();
+        assertEq(claim.owner(), governor);
+        assertEq(claim.pendingOwner(), address(0));
+        assertTrue(claim.initialized());
+    }
+
+    function testLockRevertsBeforeInitialized() public {
+        _fund();
+        vm.expectRevert(Claim2Step.NotInitializedError.selector);
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18));
+    }
+
+    function testTransferOwnershipReverts() public {
+        vm.expectRevert(Claim2Step.NotImplementedError.selector);
+        claim.transferOwnership(a);
+    }
+
+    function testRenounceOwnershipReverts() public {
+        vm.expectRevert(Claim2Step.NotImplementedError.selector);
+        claim.renounceOwnership();
+    }
+
+    function testOnlyPendingOwnerCanInitialize() public {
+        vm.expectRevert("Ownable2Step: caller is not the new owner");
+        vm.prank(a);
+        claim.acceptOwnership();
+    }
+
+    function testLockRevertsAfterDeadline() public {
+        _fund();
+        _initialize();
+        vm.warp(deadline);
+        vm.expectRevert(Claim2Step.ClosedError.selector);
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18));
+    }
+
+    function testUnlockRevertsBeforeDeadline() public {
+        _fund();
+        _initialize();
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18));
+
+        vm.warp(deadline - 1);
+        vm.expectRevert(Claim2Step.OpenedError.selector);
+        vm.prank(a);
+        claim.unlock();
+    }
+
+    // --- core economics ---
+
+    function testLockPaysBaseShareAndPreservesVotes() public {
+        _fund();
+        _initialize();
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18));
+
+        // 900e6 * 500 / 1000 = 450e6
+        assertEq(usdc.balanceOf(a), 450e6);
+        assertEq(usdc.balanceOf(address(claim)), 450e6);
+
+        // gov is custodied in a's wrapper, not a's wallet nor the claim contract
+        assertEq(gov.balanceOf(a), 0);
+        assertEq(gov.balanceOf(address(claim)), 0);
+        assertEq(_locked(a), 500e18);
+        assertEq(UFixed18.unwrap(claim.totalLocked()), 500e18);
+
+        // ...but a keeps full governance power over the locked balance
+        assertEq(gov.getVotes(a), 500e18);
+    }
+
+    function testLockAccumulatesIntoOneWrapper() public {
+        _fund();
+        _initialize();
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(200e18));
+        address wrapper = _wrapperOf(a);
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(300e18));
+
+        // reused the same wrapper; 900*200/1000 + 720*300/800 = 180 + 270 = 450
+        assertEq(_wrapperOf(a), wrapper);
+        assertEq(usdc.balanceOf(a), 450e6);
+        assertEq(_locked(a), 500e18);
+        assertEq(gov.getVotes(a), 500e18);
+    }
+
+    /// @dev Order-independent: shrinking pool over shrinking unlocked supply gives equal holders equal shares.
+    function testEqualHoldersGetEqualShares() public {
+        _fund();
+        _initialize();
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(250e18)); // 900 * 250/1000 = 225
+        vm.prank(b);
+        claim.lock(UFixed18.wrap(250e18)); // 675 * 250/750 = 225
+
+        assertEq(usdc.balanceOf(a), 225e6);
+        assertEq(usdc.balanceOf(b), 225e6);
+    }
+
+    /// @dev Full two-phase distribution: c never locks and forfeits its share to a and b, who sweep it in
+    ///      phase two pro-rata to their locked amount. Votes are preserved throughout, then returned.
+    function testFullDistribution() public {
+        _fund();
+        _initialize();
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18)); // 900 * 500/1000 = 450
+        vm.prank(b);
+        claim.lock(UFixed18.wrap(300e18)); // 450 * 300/500 = 270
+
+        assertEq(usdc.balanceOf(a), 450e6);
+        assertEq(usdc.balanceOf(b), 270e6);
+        assertEq(usdc.balanceOf(address(claim)), 180e6);
+        assertEq(gov.getVotes(a), 500e18);
+        assertEq(gov.getVotes(b), 300e18);
+
+        vm.warp(deadline);
+
+        vm.prank(a);
+        claim.unlock(); // 180 * 500/800 = 112.5
+        vm.prank(b);
+        claim.unlock(); // 67.5 * 300/300 = 67.5
+
+        assertEq(usdc.balanceOf(a), 562_500_000);
+        assertEq(usdc.balanceOf(b), 337_500_000);
+
+        // gov fully returned to the holders; votes now follow the returned tokens (self-undelegated)
+        assertEq(gov.balanceOf(a), 500e18);
+        assertEq(gov.balanceOf(b), 300e18);
+        assertEq(gov.getVotes(a), 0);
+        assertEq(_locked(a), 0);
+
+        assertEq(usdc.balanceOf(a) + usdc.balanceOf(b), REWARD);
+        assertEq(usdc.balanceOf(c), 0);
+        assertEq(usdc.balanceOf(address(claim)), 0);
+    }
+
+    function testUnclaimedLeftoverStaysStuck() public {
+        _fund();
+        _initialize();
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18));
+        vm.prank(b);
+        claim.lock(UFixed18.wrap(300e18));
+
+        vm.warp(deadline);
+        vm.prank(a);
+        claim.unlock(); // 180 * 500/800 = 112.5
+
+        assertEq(usdc.balanceOf(a), 562_500_000);
+        assertEq(usdc.balanceOf(address(claim)), 67_500_000); // b's un-swept share
+        assertEq(_locked(b), 300e18); // b's gov still custodied
+    }
+
+    function testDoubleUnlockPaysNothingExtra() public {
+        _fund();
+        _initialize();
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18));
+        vm.prank(b);
+        claim.lock(UFixed18.wrap(300e18));
+
+        vm.warp(deadline);
+        vm.prank(a);
+        claim.unlock();
+        uint256 afterFirst = usdc.balanceOf(a);
+
+        // b remains locked so totalLocked > 0; a's second unlock claims an empty wrapper
+        vm.prank(a);
+        claim.unlock();
+        assertEq(usdc.balanceOf(a), afterFirst);
+        assertEq(gov.balanceOf(a), 500e18);
+    }
+
+    /// @dev Every payout rounds down and the final claimant sweeps the remainder, so the pool stays solvent.
+    function testRoundsDownAndStaysSolvent() public {
+        usdc.mint(address(claim), 10e6);
+        _initialize();
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18)); // 10e6 * 500/1000 = 5e6
+        vm.prank(b);
+        claim.lock(UFixed18.wrap(300e18)); // 5e6 * 300/500 = 3e6
+        vm.prank(c);
+        claim.lock(UFixed18.wrap(200e18)); // 2e6 * 200/200 = 2e6
+
+        vm.warp(deadline);
+        vm.prank(a);
+        claim.unlock();
+        vm.prank(b);
+        claim.unlock();
+        vm.prank(c);
+        claim.unlock();
+
+        assertEq(usdc.balanceOf(a) + usdc.balanceOf(b) + usdc.balanceOf(c), 10e6);
+        assertEq(usdc.balanceOf(address(claim)), 0);
+    }
+
+    // --- manipulation resistance ---
+
+    /// @dev Donating gov directly to the claim contract does not shrink `unlockedSupply` (it is derived from
+    ///      internal `totalLocked`, not a live balance), so it cannot inflate a locker's reward.
+    function testGovDonationDoesNotInflateReward() public {
+        _fund();
+        _initialize();
+
+        // c donates its entire holding straight to the claim contract (a transfer, not a mint: supply fixed)
+        vm.prank(c);
+        gov.transfer(address(claim), 200e18);
+
+        // a still receives exactly its fair base share
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18));
+        assertEq(usdc.balanceOf(a), 450e6);
+    }
+
+    /// @dev Live USDC added to the pool simply joins it and is distributed to whoever locks after.
+    function testUsdcAddedToPoolIsDistributed() public {
+        _fund();
+        _initialize();
+        usdc.mint(address(claim), 100e6); // pool now 1000e6
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18)); // 1000e6 * 500/1000 = 500e6
+        assertEq(usdc.balanceOf(a), 500e6);
+    }
+
+    /// @dev Regression for the wrapper-donation bug: gov sent into a locker's wrapper must not inflate that
+    ///      locker's reward nor corrupt `totalLocked` (which would strand other lockers). Accounting is driven
+    ///      by the internal `lockedOf` ledger, so the donation is simply gifted back on exit.
+    function testWrapperDonationDoesNotInflateOrStrand() public {
+        _fund();
+        _initialize();
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(400e18)); // a keeps 100 spare; phase-1 = 900 * 400/1000 = 360
+        vm.prank(b);
+        claim.lock(UFixed18.wrap(300e18)); // phase-1 = 540 * 300/600 = 270
+
+        // a donates its 100 spare straight into its own wrapper (address is public)
+        address wrapperA = _wrapperOf(a);
+        vm.prank(a);
+        gov.transfer(wrapperA, 100e18);
+
+        vm.warp(deadline);
+
+        vm.prank(a);
+        claim.unlock();
+        // exactly the fair share (900*400/700), not the inflated 500-based amount, and gov (incl. gift) back
+        assertEq(usdc.balanceOf(a), uint256(360e6) + uint256(270e6) * 400 / 700);
+        assertEq(gov.balanceOf(a), 500e18);
+
+        // totalLocked fell by the ledgered 400, not the wrapper's 500, so b still exits cleanly
+        assertEq(UFixed18.unwrap(claim.totalLocked()), 300e18);
+        vm.prank(b);
+        claim.unlock();
+        assertEq(gov.balanceOf(b), 300e18);
+        assertEq(usdc.balanceOf(a) + usdc.balanceOf(b), REWARD);
+    }
+
+    /// @dev Unlocking without ever having locked reverts (no wrapper deployed); nothing is at risk.
+    function testUnlockWithoutLockReverts() public {
+        _fund();
+        _initialize();
+        vm.warp(deadline);
+
+        vm.expectRevert();
+        vm.prank(a);
+        claim.unlock();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a two-step claim process allowing participants to lock governance tokens before a deadline and unlock them afterward.
  - Added proportional reward distribution with support for preserving delegated voting power during the lock period.
  - Added governance-controlled initialization and lifecycle safeguards.

- **Tests**
  - Added comprehensive coverage for claim timing, rewards, voting power, rounding, donations, and invalid actions.
  - Added an end-to-end mainnet governance flow test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->