### PR TITLE
Add escape hatch to Claim2Step

### DIFF
--- a/packages/emptyset-reserve/contracts/claim/Claim2Step.sol
+++ b/packages/emptyset-reserve/contracts/claim/Claim2Step.sol
@@ -96,6 +96,11 @@ contract Claim2Step is Ownable2Step {
         emit Unlocked(msg.sender, amount, reward);
     }
 
+    function close() external onlyOwner {
+        if (!closed()) revert OpenedError();
+        fiat.push(owner());
+    }
+
     function initialized() public view returns (bool) {
         return pendingOwner() == address(0);
     }

--- a/test/reserve/Claim2Step.mainnet.t.sol
+++ b/test/reserve/Claim2Step.mainnet.t.sol
@@ -177,7 +177,7 @@ contract Claim2StepMainnetTest is Test {
         assertFalse(claim.closed()); // still inside the lock window
         _passLockedHolderProposal(alice, bob, aLock, bLock);
 
-        // --- phase 2: unlock ---
+        // --- phase 2: alice exits; bob is a straggler whose share becomes leftover ---
         vm.warp(deadline);
         assertTrue(claim.closed());
 
@@ -188,13 +188,24 @@ contract Claim2StepMainnetTest is Test {
         assertEq(ess.balanceOf(alice), aLock); // gov returned...
         assertEq(ess.getCurrentVotes(alice), 0); // ...and voting power released with it
 
-        // bob is the last locker, so his unlock sweeps the remainder of the pool
-        uint256 sweepB = usdc.balanceOf(address(claim));
+        // bob never returns to unlock, so his reward share stays behind in the pool
+        uint256 leftover = usdc.balanceOf(address(claim));
+        assertGt(leftover, 0);
+
+        // well after close, governance (the owner) recalls the leftover to the timelock at its discretion.
+        // pranking the timelock stands in for a follow-up proposal executing claim.close().
+        vm.warp(deadline + 30 days);
+        uint256 ownerBefore = usdc.balanceOf(TIMELOCK);
+        vm.prank(TIMELOCK);
+        claim.close();
+        assertEq(usdc.balanceOf(address(claim)), 0);
+        assertEq(usdc.balanceOf(TIMELOCK), ownerBefore + leftover);
+
+        // the recall does not strand bob's collateral: he can still unlock to recover his ESS (no reward left)
         vm.prank(bob);
         claim.unlock();
-        assertEq(usdc.balanceOf(bob), rewardB + sweepB);
         assertEq(ess.balanceOf(bob), bLock);
-        assertEq(usdc.balanceOf(address(claim)), 0);
+        assertEq(ess.getCurrentVotes(bob), 0);
     }
 
     /// @dev A fresh proposal, proposed by locked-holder `alice` and carried to execution by the votes of both

--- a/test/reserve/Claim2Step.t.sol
+++ b/test/reserve/Claim2Step.t.sol
@@ -355,4 +355,70 @@ contract Claim2StepTest is Test {
         vm.prank(a);
         claim.unlock();
     }
+
+    // --- owner recall of leftover funds ---
+
+    /// @dev After the deadline the owner may recall whatever fiat is left (e.g. the share of lockers who never
+    ///      returned to unlock) to itself. Intended to be used well after close, at the owner's discretion.
+    function testCloseRecallsLeftoverToOwner() public {
+        _fund();
+        _initialize();
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18));
+        vm.prank(b);
+        claim.lock(UFixed18.wrap(300e18));
+
+        vm.warp(deadline);
+        vm.prank(a);
+        claim.unlock(); // a exits; b's share is left behind in the pool
+
+        uint256 leftover = usdc.balanceOf(address(claim));
+        assertGt(leftover, 0);
+        uint256 ownerBefore = usdc.balanceOf(governor);
+
+        vm.prank(governor);
+        claim.close();
+
+        assertEq(usdc.balanceOf(address(claim)), 0);
+        assertEq(usdc.balanceOf(governor), ownerBefore + leftover);
+    }
+
+    function testCloseRevertsBeforeDeadline() public {
+        _fund();
+        _initialize();
+
+        vm.expectRevert(Claim2Step.OpenedError.selector);
+        vm.prank(governor);
+        claim.close();
+    }
+
+    function testCloseOnlyOwner() public {
+        _fund();
+        _initialize();
+        vm.warp(deadline);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(a);
+        claim.close();
+    }
+
+    /// @dev Recalling the pool does not trap a locker's collateral: they can still unlock to recover their gov,
+    ///      they simply forgo any fiat reward once it has been swept.
+    function testCloseDoesNotStrandLockerCollateral() public {
+        _fund();
+        _initialize();
+
+        vm.prank(a);
+        claim.lock(UFixed18.wrap(500e18));
+
+        vm.warp(deadline);
+        vm.prank(governor);
+        claim.close(); // owner recalls the entire remaining pool
+
+        vm.prank(a);
+        claim.unlock();
+        assertEq(gov.balanceOf(a), 500e18); // gov returned
+        assertEq(usdc.balanceOf(address(claim)), 0);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an owner-controlled option to close claims after the deadline.
  * Any leftover funds are returned to the owner when the claim is closed.
  * Participants can still unlock their collateral after closure.

* **Bug Fixes**
  * Prevented leftover funds from becoming stranded when participants exit early.
  * Ensured governance collateral and voting power are properly released after closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->